### PR TITLE
Parcel weight is meant to be string

### DIFF
--- a/parcel.go
+++ b/parcel.go
@@ -24,7 +24,7 @@ type ParcelParams struct {
 	PhoneNumber      string
 	ExternalID       string
 	ToServicePointID int64
-	Weight           int64
+	Weight           string
 	OrderNumber      string
 	SenderID         int64
 }
@@ -46,7 +46,7 @@ type Parcel struct {
 	PhoneNumber    *string     `json:"phone_number"`
 	TrackingNumber string      `json:"tracking_number"`
 	ServicePointID *int64      `json:"to_service_point"`
-	Weight         int64       `json:"weight"`
+	Weight         string       `json:"weight"`
 	Label          string      `json:"label"`
 	OrderNumber    string      `json:"order_number"`
 	IsReturn       bool        `json:"is_return"`
@@ -219,15 +219,13 @@ func (p *ParcelResponseContainer) GetResponse() interface{} {
 		Note:           p.Parcel.Note,
 		CarrierCode:    p.Parcel.Carrier.Code,
 		Data:           p.Parcel.Data,
+		Weight:		p.Parcel.Weight
 	}
 
 	layout := "02-01-2006 15:04:05"
 	createdAt, _ := time.Parse(layout, p.Parcel.DateCreated)
 	parcel.CreatedAt = createdAt
 
-	weightFloat, _ := strconv.ParseFloat(p.Parcel.Weight, 64)
-	weight := int64(weightFloat * 1000)
-	parcel.Weight = weight
 	return &parcel
 }
 

--- a/parcel.go
+++ b/parcel.go
@@ -219,7 +219,7 @@ func (p *ParcelResponseContainer) GetResponse() interface{} {
 		Note:           p.Parcel.Note,
 		CarrierCode:    p.Parcel.Carrier.Code,
 		Data:           p.Parcel.Data,
-		Weight:		p.Parcel.Weight
+		Weight:		p.Parcel.Weight,
 	}
 
 	layout := "02-01-2006 15:04:05"


### PR DESCRIPTION
Parcel weight is a string because Sendcloud support parcels weighing less than 1kg. Instead of using a float, it should just be the data type that the API insists upon (https://docs.sendcloud.sc/api/v2/shipping/#create-a-parcel). To make it more reliable.