### PR TITLE
fix: include weight in request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![build](https://github.com/afosto/sendcloud-go/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/afosto/sendcloud-go/actions/workflows/build-and-test.yml)
 # sendcloud-go
 
 An API-client for Sendcloud written in Golang.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/afosto/sendcloud-go
 
 go 1.15
 
-require golang.org/x/text v0.3.5
+require (
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/text v0.3.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parcel.go
+++ b/parcel.go
@@ -69,6 +69,7 @@ type ParcelRequest struct {
 	PostalCode       string  `json:"postal_code"`
 	CountryState     string  `json:"country_state"`
 	Country          string  `json:"country"`
+	Weight           *string `json:"weight,omitempty"`
 	Telephone        string  `json:"telephone"`
 	Email            string  `json:"email"`
 	RequestLabel     bool    `json:"request_label"`
@@ -117,7 +118,7 @@ type ParcelResponse struct {
 	ToServicePointID    *int64          `json:"to_service_point"`
 	Telephone           *string         `json:"telephone"`
 	TrackingNumber      string          `json:"tracking_number"`
-	Weight              string          `json:"weight"`
+	Weight              *string         `json:"weight"`
 	Label               LabelResponse   `json:"label"`
 	OrderNumber         string          `json:"order_number"`
 	InsuredValue        int64           `json:"insured_value"`
@@ -188,6 +189,9 @@ func (p *ParcelParams) GetPayload() interface{} {
 	if p.ToServicePointID != 0 {
 		parcel.ToServicePointID = &p.ToServicePointID
 	}
+	if p.Weight != "" {
+		parcel.Weight = &p.Weight
+	}
 
 	ar := ParcelRequestContainer{Parcel: parcel}
 	return ar
@@ -218,12 +222,15 @@ func (p *ParcelResponseContainer) GetResponse() interface{} {
 		Note:           p.Parcel.Note,
 		CarrierCode:    p.Parcel.Carrier.Code,
 		Data:           p.Parcel.Data,
-		Weight:         p.Parcel.Weight,
 	}
 
 	layout := "02-01-2006 15:04:05"
 	createdAt, _ := time.Parse(layout, p.Parcel.DateCreated)
 	parcel.CreatedAt = createdAt
+
+	if p.Parcel.Weight != nil {
+		parcel.Weight = *p.Parcel.Weight
+	}
 
 	return &parcel
 }

--- a/parcel.go
+++ b/parcel.go
@@ -69,7 +69,7 @@ type ParcelRequest struct {
 	PostalCode       string  `json:"postal_code"`
 	CountryState     string  `json:"country_state"`
 	Country          string  `json:"country"`
-	Weight           *string `json:"weight,omitempty"`
+	Weight           string  `json:"weight,omitempty"`
 	Telephone        string  `json:"telephone"`
 	Email            string  `json:"email"`
 	RequestLabel     bool    `json:"request_label"`
@@ -190,7 +190,7 @@ func (p *ParcelParams) GetPayload() interface{} {
 		parcel.ToServicePointID = &p.ToServicePointID
 	}
 	if p.Weight != "" {
-		parcel.Weight = &p.Weight
+		parcel.Weight = p.Weight
 	}
 
 	ar := ParcelRequestContainer{Parcel: parcel}

--- a/parcel.go
+++ b/parcel.go
@@ -222,15 +222,12 @@ func (p *ParcelResponseContainer) GetResponse() interface{} {
 		Note:           p.Parcel.Note,
 		CarrierCode:    p.Parcel.Carrier.Code,
 		Data:           p.Parcel.Data,
+		Weight:         p.Parcel.Weight,
 	}
 
 	layout := "02-01-2006 15:04:05"
 	createdAt, _ := time.Parse(layout, p.Parcel.DateCreated)
 	parcel.CreatedAt = createdAt
-
-	if p.Parcel.Weight != "" {
-		parcel.Weight = p.Parcel.Weight
-	}
 
 	return &parcel
 }

--- a/parcel.go
+++ b/parcel.go
@@ -118,7 +118,7 @@ type ParcelResponse struct {
 	ToServicePointID    *int64          `json:"to_service_point"`
 	Telephone           *string         `json:"telephone"`
 	TrackingNumber      string          `json:"tracking_number"`
-	Weight              *string         `json:"weight"`
+	Weight              string          `json:"weight"`
 	Label               LabelResponse   `json:"label"`
 	OrderNumber         string          `json:"order_number"`
 	InsuredValue        int64           `json:"insured_value"`
@@ -228,8 +228,8 @@ func (p *ParcelResponseContainer) GetResponse() interface{} {
 	createdAt, _ := time.Parse(layout, p.Parcel.DateCreated)
 	parcel.CreatedAt = createdAt
 
-	if p.Parcel.Weight != nil {
-		parcel.Weight = *p.Parcel.Weight
+	if p.Parcel.Weight != "" {
+		parcel.Weight = p.Parcel.Weight
 	}
 
 	return &parcel

--- a/parcel_test.go
+++ b/parcel_test.go
@@ -27,13 +27,14 @@ func TestGetPayload(t *testing.T) {
 	for _, test := range tests {
 		payload := test.Params.GetPayload()
 		b, _ := json.Marshal(payload)
-		var obj sendcloud.ParcelRequestContainer
+		var obj map[string]map[string]interface{}
 
 		err := json.Unmarshal(b, &obj)
 		assert.NoError(t, err)
 
-		if test.Params.Weight != "" {
-			assert.Equal(t, test.Params.Weight, obj.Parcel.Weight, test.Name)
+		if test.Params.Weight == "" {
+			_, ok := obj["parcel"]["weight"]
+			assert.False(t, ok)
 		}
 	}
 }

--- a/parcel_test.go
+++ b/parcel_test.go
@@ -28,11 +28,12 @@ func TestGetPayload(t *testing.T) {
 		payload := test.Params.GetPayload()
 		b, _ := json.Marshal(payload)
 		var obj sendcloud.ParcelRequestContainer
-		json.Unmarshal(b, &obj)
+
+		err := json.Unmarshal(b, &obj)
+		assert.NoError(t, err)
+
 		if test.Params.Weight != "" {
-			assert.Equal(t, test.Params.Weight, *obj.Parcel.Weight, test.Name)
-		} else {
-			assert.Nil(t, obj.Parcel.Weight, test.Name)
+			assert.Equal(t, test.Params.Weight, obj.Parcel.Weight, test.Name)
 		}
 	}
 }

--- a/parcel_test.go
+++ b/parcel_test.go
@@ -1,0 +1,73 @@
+package sendcloud_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/afosto/sendcloud-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPayload(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Params sendcloud.ParcelParams
+	}{
+		{
+			Name:   "Should ignore empty weight",
+			Params: sendcloud.ParcelParams{},
+		},
+		{
+			Name: "Should include weight in request",
+			Params: sendcloud.ParcelParams{
+				Weight: "0.040",
+			},
+		},
+	}
+	for _, test := range tests {
+		payload := test.Params.GetPayload()
+		b, _ := json.Marshal(payload)
+		var obj sendcloud.ParcelRequestContainer
+		json.Unmarshal(b, &obj)
+		if test.Params.Weight != "" {
+			assert.Equal(t, test.Params.Weight, *obj.Parcel.Weight, test.Name)
+		} else {
+			assert.Nil(t, obj.Parcel.Weight, test.Name)
+		}
+	}
+}
+
+func TestGetResponse(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Response sendcloud.ParcelResponseContainer
+		Out      sendcloud.Parcel
+	}{
+		{
+			Name: "Should ignore nil weight",
+			Response: sendcloud.ParcelResponseContainer{
+				Parcel: sendcloud.ParcelResponse{},
+			},
+			Out: sendcloud.Parcel{},
+		},
+		{
+			Name: "Should include weight",
+			Response: sendcloud.ParcelResponseContainer{
+				Parcel: sendcloud.ParcelResponse{
+					Weight: sendcloud.String("0.05"),
+				},
+			},
+			Out: sendcloud.Parcel{
+				Weight: "0.05",
+			},
+		},
+	}
+	for _, test := range tests {
+		res := test.Response.GetResponse()
+		if test.Response.Parcel.Weight != nil {
+			assert.Equal(t, test.Out.Weight, res.(*sendcloud.Parcel).Weight, test.Name)
+		} else {
+			assert.Equal(t, res.(*sendcloud.Parcel).Weight, "", test.Name)
+		}
+	}
+}

--- a/parcel_test.go
+++ b/parcel_test.go
@@ -54,7 +54,7 @@ func TestGetResponse(t *testing.T) {
 			Name: "Should include weight",
 			Response: sendcloud.ParcelResponseContainer{
 				Parcel: sendcloud.ParcelResponse{
-					Weight: sendcloud.String("0.05"),
+					Weight: "0.05",
 				},
 			},
 			Out: sendcloud.Parcel{
@@ -64,7 +64,7 @@ func TestGetResponse(t *testing.T) {
 	}
 	for _, test := range tests {
 		res := test.Response.GetResponse()
-		if test.Response.Parcel.Weight != nil {
+		if test.Response.Parcel.Weight != "" {
 			assert.Equal(t, test.Out.Weight, res.(*sendcloud.Parcel).Weight, test.Name)
 		} else {
 			assert.Equal(t, res.(*sendcloud.Parcel).Weight, "", test.Name)

--- a/sendcloud.go
+++ b/sendcloud.go
@@ -105,3 +105,8 @@ func getUrl(uri string) string {
 
 	return url
 }
+
+// Converts string to string pointer
+func String(s string) *string {
+	return &s
+}

--- a/sendcloud.go
+++ b/sendcloud.go
@@ -105,8 +105,3 @@ func getUrl(uri string) string {
 
 	return url
 }
-
-// Converts string to string pointer
-func String(s string) *string {
-	return &s
-}


### PR DESCRIPTION
Weight is an optional param, so it must include it in request and not just the response
parcel.go

Includes tests `parcel_test.go`
